### PR TITLE
Resolve Legacy Python and SQS Endpoint Issues

### DIFF
--- a/selectable_pdf_infra/README.md
+++ b/selectable_pdf_infra/README.md
@@ -8,7 +8,7 @@ scanned PDFs (i.e. where the text cannot be selected) into Selectable PDF
 
 To deploy this stack, you need:
 * An AWS account
-* Python 3.6 or higher
+* Python 3.8 or higher: [Lambda Python Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
 * [AWS CLI](https://aws.amazon.com/cli/): configured with` AWS configure`
 * [AWS CDK](https://aws.amazon.com/cdk/): version 2.X or higher
 
@@ -25,6 +25,13 @@ To create the virtualenv it assumes that there is a `python3` executable in your
 path with access to the `venv` package. If for any reason the automatic creation 
 of the virtualenv fails, you can create the virtualenv manually once the init 
 process completes.
+
+
+> [!IMPORTANT]
+> The virtualenv you create in the following step should match the Python version that the
+lambdas will utilize. A mismatch between the local build and the lambda run
+will result in dependency errors with PyMuPDFlike [this](https://github.com/keithrozario/Klayers/issues/168).
+
 
 To manually create a virtualenv on MacOS and Linux:
 ```

--- a/selectable_pdf_infra/selectable_pdf_infra/lambda/process_textract/main.py
+++ b/selectable_pdf_infra/selectable_pdf_infra/lambda/process_textract/main.py
@@ -47,12 +47,11 @@ def lambda_handler(event, context):
     logger.info('event: {}'.format(event))
     args = parse_args(event)
 
-    # Get AWS connectors. The SQS client need the legacy endpoint, but when calling
-    # a queue with the client, the queue URL must have the new endpoint:
+    # Get AWS connectors.
     # https://docs.aws.amazon.com/general/latest/gr/sqs-service.html#sqs_region
     ddb_doc_table = ProcessingDdbTable(args['ddb_documents_table'])
-    sqs_legacy_endpoint_url = f"https://{args['region']}.queue.amazonaws.com"
-    sqs_client = boto3.client('sqs', endpoint_url=sqs_legacy_endpoint_url)
+    sqs_endpoint_url = f"https://sqs.{args['region']}.amazonaws.com"
+    sqs_client = boto3.client('sqs', endpoint_url=sqs_endpoint_url)
 
     # for each job (generally, only one per sns message):
     # 1. get the textract blocks
@@ -106,7 +105,7 @@ def lambda_handler(event, context):
                 MessageBody=json.dumps(tt_job_info),
             )
         except Exception as ex:
-            logger.error(f"Cannot send message to SQS queue {args['textract_res_queue_url']}")
+            logger.error(f"Cannot send message to SQS queue {args['textract_res_queue_url']}, client endpoint configured {sqs_endpoint_url}")
             raise ex
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Firstly, I wanted to thank you for making this example. It works super well and has been a pleasure to work with. I had to make some changes to it to bring it up to the current requirements for lambda and SQS, but otherwise it functions as expected.

- Updated the README to provide information about your local Python version needing to match that of the AWS Lambda Python runtime to be used. The issue is detailed [here](https://github.com/keithrozario/Klayers/issues/168) and [here](https://github.com/pymupdf/PyMuPDF/issues/430). The `PyMuPDFlike` library is platform and version specific, so compiling with another version locally than the destination python runtime will result in dependency errors. 
- The legacy SQS endpoint is no longer accessible within the lambda's VPC without private DNS, and attempting to use it results in the lambda failing to write the message to SQS for the next step in the process. This has been updated to use the currently accepted and required SQS endpoint, which results in successful message delivery. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
